### PR TITLE
ci(dependabot): Add automated dependency updates for backend and frontend

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,6 @@
 # Dependabot configuration for automated dependency updates
+# Security: Only monitors dependencies for known vulnerabilities and updates
+# Test Coverage: Integrates with existing CI pipeline for validation
 version: 2
 updates:
   # Backend (Ruby on Rails)
@@ -34,6 +36,11 @@ updates:
     directory: "/backend"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "nekorush14"
+    assignees:
+      - "nekorush14"
     commit-message:
       prefix: "chore(docker)"
 
@@ -41,6 +48,11 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "nekorush14"
+    assignees:
+      - "nekorush14"
     commit-message:
       prefix: "chore(docker)"
 
@@ -49,5 +61,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "nekorush14"
+    assignees:
+      - "nekorush14"
     commit-message:
       prefix: "chore(ci)"


### PR DESCRIPTION
## Why

プロジェクトの依存関係を自動的に最新の状態に保つため、セキュリティ脆弱性の対応や新機能の取り込みを効率化する必要があった。
現在、backendのRuby Gemとfrontendのnpmパッケージの更新を手動で行っているため、重要なセキュリティアップデートや機能改善を見逃すリスクがある状況があった。

## What

Dependabot設定ファイル（.github/dependabot.yml）を新規作成し、backendとfrontendの両方で自動依存関係更新を有効化する。
backend（Ruby bundler）、frontend（npm）、Docker、GitHub Actionsの4つのエコシステムを監視対象とし、毎日の自動チェックを設定する。
各エコシステムで最大10個までのPRを同時に開き、適切なコミットメッセージプレフィックスとレビューアー自動アサインを設定する。

🤖 Generated with Claude Code