### PR TITLE
fix(frontend): resolve TypeScript version mismatch in package-lock.json

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4717,9 +4717,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {


### PR DESCRIPTION
## Why

frontendのCIパイプラインで`npm ci`コマンドが失敗していた。原因は`package.json`で指定されているTypeScriptのバージョン（`~5.8.3`）と、`package-lock.json`に記録されている実際のバージョン（`5.9.2`）が一致していなかったため。この不整合により、CIの依存関係インストールステップで「`npm ci` can only install packages when your package.json and package-lock.json are in sync」エラーが発生していた。

## What

`package-lock.json`内のTypeScriptバージョンを`5.8.3`に修正し、`package.json`との同期を取る。これにより`npm ci`コマンドが正常に実行され、frontendのlintおよびtestジョブが成功するようになる。

🤖 Generated with Claude Code