### PR TITLE
ci(dependabot): Change update interval from daily to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
   - package-ecosystem: "bundler"
     directory: "/backend"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     open-pull-requests-limit: 10
     reviewers:
       - "nekorush14"
@@ -21,7 +21,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     open-pull-requests-limit: 10
     reviewers:
       - "nekorush14"
@@ -35,7 +35,7 @@ updates:
   - package-ecosystem: "docker"
     directory: "/backend"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     open-pull-requests-limit: 10
     reviewers:
       - "nekorush14"
@@ -47,7 +47,7 @@ updates:
   - package-ecosystem: "docker"
     directory: "/frontend"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     open-pull-requests-limit: 10
     reviewers:
       - "nekorush14"
@@ -60,7 +60,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     open-pull-requests-limit: 10
     reviewers:
       - "nekorush14"


### PR DESCRIPTION
## Why

dependabotの更新頻度が日次設定になっており、頻繁にプルリクエストが作成されてレビュー負荷が高くなっている。
開発チームのレビューキャパシティと依存関係の更新による潜在的リスクを考慮し、より適切な更新頻度に調整する必要がある。

## What

dependabot.ymlファイルにて、全てのパッケージエコシステム（bundler、npm、docker、github-actions）の更新間隔を日次から月次に変更する。
これにより依存関係の更新頻度が適切になり、レビュー負荷が軽減される。

🤖 Generated with Claude Code